### PR TITLE
[WIP] Cards template for double side cut out

### DIFF
--- a/inst/cardtemplates/Double.Rnw
+++ b/inst/cardtemplates/Double.Rnw
@@ -1,0 +1,62 @@
+% this createsactual paper business cards for q items as follows
+ % sized 85*84mm (business cards)
+ % 10 per a4 page
+ % on Avery Zweckform C32010
+\documentclass[a4paper,12pt]{article}  % because, why not?
+\usepackage{longtable}  % for multi-page tables
+\usepackage{array}  % for center, bottom vertical alignment in tables
+\usepackage{calc}  % to easily identify dimensions etc.
+\usepackage[T1]{fontenc}  % read in eur sim
+\usepackage[utf8]{inputenc}  % allow accents etc in inputs
+<<babel.language, echo=FALSE, results="asis" >>=
+if(!is.null(babel.language)) {
+  cat(
+    "\\usepackage[",
+    babel.language, # for international support
+    "]{babel}",
+    sep="" 
+  )
+}
+@
+\usepackage[
+  a4paper,
+  height=54mm*5,  % 5 cards on top of one another
+  width=85mm*2+10mm,  % 2 cards abreast, 10mm aisle
+  vcentering,  % should be vertically centered
+  hcentering  % should be horizontaly centered
+  ]
+  {geometry
+}
+\begin{document}
+\pagestyle{empty}
+\setlength{\tabcolsep}{5mm}  % for margins and "aisle" margin between cards, fix by trial and error
+\newcolumntype{H}{>{\centering\arraybackslash\Huge\ttfamily}m}  % need this because font size should be different for ID
+<<make.cards, results='asis', echo=FALSE, warning=FALSE, message=FALSE>>=
+q.set.print$empty <- c("\\rule[-27mm]{0mm}{54mm}")  # creates empty column with a white height line to make sure rows have some height
+print.xtable(
+  xtable(
+      x     = q.set.print[c("id","empty","full wording")],
+      type  = "latex",
+      align = c(
+      	"m{0mm}","|",  # this is just for the rownames, isn't actually printed
+      	"m{75mm}","|",  # this is for the hash or id, must be a little shorter to fit
+      	"m{0mm}","|",  # empty column in the middle with stretcher vertical line, width is given by colsep in the above (no need for extra width here) - this adds up to 1cm anyway
+      	"m{75mm}","|"  # the real deal with the full item
+      	)
+  ), #  smaller than cards for margin,
+  tabular.environment = "longtable",
+  latex.environment = "center",
+  table.placement = "p",
+  floating = FALSE,
+  include.rownames = FALSE,
+  include.colnames = FALSE,
+  comment = FALSE,
+  #if(!is.null(wording.font.size)) {
+  #  paste(size = wording.font.size)
+  #}
+  size = wording.font.size,
+  sanitize.text.function = identity,
+  hline.after = c(-1:nrow(q.set.print))
+)
+@
+\end{document}

--- a/inst/cardtemplates/DoubleSideCut.Rnw
+++ b/inst/cardtemplates/DoubleSideCut.Rnw
@@ -1,8 +1,9 @@
 % this createsactual paper business cards for q items as follows
  % sized 85*84mm (business cards)
  % 10 per a4 page
- % on Avery Zweckform C32010
-\documentclass[a4paper,12pt]{article}  % because, why not?
+ % printed in double side for cutting out
+ % based on AveryZweckformC32010.Rnw
+\documentclass[a4paper,12pt,twoside]{article}  % because, why not?
 \usepackage{longtable}  % for multi-page tables
 \usepackage{array}  % for center, bottom vertical alignment in tables
 \usepackage{calc}  % to easily identify dimensions etc.
@@ -32,16 +33,36 @@ if(!is.null(babel.language)) {
 \setlength{\tabcolsep}{5mm}  % for margins and "aisle" margin between cards, fix by trial and error
 \newcolumntype{H}{>{\centering\arraybackslash\Huge\ttfamily}m}  % need this because font size should be different for ID
 <<make.cards, results='asis', echo=FALSE, warning=FALSE, message=FALSE>>=
-q.set.print$empty <- c("\\rule[-27mm]{0mm}{54mm}")  # creates empty column with a white height line to make sure rows have some height
+q.set.print$id <- paste("\\centering \\textbf{", q.set.print$id, "}", sep="") # make the id centered and bold
+
+# re-arrange the dataset for use with xtable
+ids <- q.set.print[,"id"]
+full <- as.character(q.set.print[,"full wording"])
+q.set.print.double <- data.frame(column1 = NA, column2 = NA)[character(0), ]
+from <- 0
+to <- ceiling(nrow(q.set.print)/10-1)
+for (i in from:to) {
+  rows <- c(1:10) + i * 10
+  sub_ids <- ids[rows]
+  pageids <- cbind(sub_ids[1:5], sub_ids[6:10])
+  sub_full <- full[rows]
+  pagefull <- cbind(sub_full[6:10], sub_full[1:5])
+  q.set.print.double <- rbind(q.set.print.double, pageids, pagefull)
+}
+
+colnames(q.set.print.double) <- c("column1", "column2")
+
+q.set.print.double$empty <- c("\\rule[-27mm]{0mm}{52mm}")  # creates empty column with a white height line to make sure rows have some height
+
 print.xtable(
   xtable(
-      x     = q.set.print[c("id","empty","full wording")],
+      x     = q.set.print.double[c("column1","empty","column2")],
       type  = "latex",
       align = c(
       	"m{0mm}","|",  # this is just for the rownames, isn't actually printed
-      	"m{75mm}","|",  # this is for the hash or id, must be a little shorter to fit
+      	"m{75mm}","|",  # this is for the first column
       	"m{0mm}","|",  # empty column in the middle with stretcher vertical line, width is given by colsep in the above (no need for extra width here) - this adds up to 1cm anyway
-      	"m{75mm}","|"  # the real deal with the full item
+      	"m{75mm}","|"  # this is for the second column
       	)
   ), #  smaller than cards for margin,
   tabular.environment = "longtable",
@@ -56,7 +77,7 @@ print.xtable(
   #}
   size = wording.font.size,
   sanitize.text.function = identity,
-  hline.after = c(-1:nrow(q.set.print))
+  hline.after = c(0:nrow(q.set.print))
 )
 @
 \end{document}

--- a/inst/cardtemplates/DoubleSideCut.Rnw
+++ b/inst/cardtemplates/DoubleSideCut.Rnw
@@ -3,7 +3,7 @@
  % 10 per a4 page
  % printed in double side for cutting out
  % based on AveryZweckformC32010.Rnw
-\documentclass[a4paper,12pt,twoside]{article}  % because, why not?
+\documentclass[a4paper,12pt]{article}  % because, why not?
 \usepackage{longtable}  % for multi-page tables
 \usepackage{array}  % for center, bottom vertical alignment in tables
 \usepackage{calc}  % to easily identify dimensions etc.
@@ -33,7 +33,7 @@ if(!is.null(babel.language)) {
 \setlength{\tabcolsep}{5mm}  % for margins and "aisle" margin between cards, fix by trial and error
 \newcolumntype{H}{>{\centering\arraybackslash\Huge\ttfamily}m}  % need this because font size should be different for ID
 <<make.cards, results='asis', echo=FALSE, warning=FALSE, message=FALSE>>=
-q.set.print$id <- paste("\\centering \\textbf{", q.set.print$id, "}", sep="") # make the id centered and bold
+q.set.print$id <- paste("\\begin{center} \\textbf{", q.set.print$id, "} \\end{center}", sep="") # make the id centered and bold
 
 # re-arrange the dataset for use with xtable
 ids <- q.set.print[,"id"]
@@ -77,7 +77,7 @@ print.xtable(
   #}
   size = wording.font.size,
   sanitize.text.function = identity,
-  hline.after = c(0:nrow(q.set.print))
+  hline.after = c(0:(nrow(q.set.print.double)-1))
 )
 @
 \end{document}


### PR DESCRIPTION
This PR addes a make.cards template which creates a pdf that is intended for double sided printing. This way the cards can be cut out and the id is on the back of the full wording. See issue #354 